### PR TITLE
Fix: Documented output is outdated + update changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,17 @@ JSON.stringify(notableDays2018) === [
 ]
 ```
 
+
+
 ## Changelog
 
-### 3.1.0 (upcoming)
+### Upcoming...
+<!-- Add new items here -->
+- …
 
+
+### 3.1.0
+_20-04-28_
 - Add "Hrekkjavaka"
 - Demote "Þorláksmessa" to notable day status
 - Add flagging of "half-day" holidays
@@ -60,15 +67,18 @@ JSON.stringify(notableDays2018) === [
 - Improve performance
 - Minor bugfixes
 
-### 3.0.0
 
+### 3.0.0
+_2016-06-18_
 - Calculate holidays instead of scraping them.
 - Removed promises (breaking changes).
 
-### 2.0.0
 
+### 2.0.0
+_2016-03-28_
 - Use promises instead of callbacks.
 
-### 1.0.0
 
+### 1.0.0
+_2016-03-27_
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -27,22 +27,25 @@ var otherDays = fridagar.getOtherDays(2016, 6);
 ## Sample output
 
 ```javascript
-[
+const notableDays2018 = fridagar.getAllDays(2018 );
+JSON.stringify(notableDays2018) === [
+  ...
   {
-    "date": "2016-06-17T00:00:00.000Z",
-    "description": "Þjóðhátíðardagur Íslendinga",
+    "date": "2018-12-23T00:00:00.000Z",
+    "description": "Þorláksmessa",
+  },
+  {
+    "date": "2018-12-24T00:00:00.000Z",
+    "description": "Aðfangadagur",
+    "halfDay": true,
     "holiday": true
   },
   {
-    "date": "2016-06-20T22:34:00.000Z",
-    "description": "Sumarsólstöður",
-    "holiday": false
+    "date": "2018-12-25T00:00:00.000Z",
+    "description": "Jóladagur",
+    "holiday": true
   },
-  {
-    "date": "2016-06-24T00:00:00.000Z",
-    "description": "Jónsmessa",
-    "holiday": false
-  }
+  ...
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ JSON.stringify(notableDays2018) === [
 - …
 
 
+### 3.1.1
+_20-05-xx_
+- Fix documentation
+
+
 ### 3.1.0
 _20-04-28_
 - Add "Hrekkjavaka"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fridagar",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Returns Icelandic holidays and other special days",
   "main": "fridagar.js",
   "scripts": {


### PR DESCRIPTION
Ég sé líka að þrátt fyrir v3.1.0 taggið um daginn, þá var sú útgáfa aldrei gefin út á npmjs.org.

Spurning um að keyra `npm publish` áður en þú mergjar þessu :-)